### PR TITLE
Added functionallity to include html from a file as a banner element within the generated page

### DIFF
--- a/compilePages.sh
+++ b/compilePages.sh
@@ -9,6 +9,7 @@ DEVNET_URL=$4
 BREADCRUMB=$5
 DIR_NAME=$6
 BRANCH=${7:-master}
+BANNER_HTML_FILE=$8
 VOLUME_PATH=${VOLUME_PATH:-/docker-data/jekyll-generated-pages}
 
 IMAGE_NAME=nhsd/jekyllpublish
@@ -42,5 +43,5 @@ docker $TARGET_PREFIX run \
 	--add-host developer.nhs.uk:13.69.155.33 \
 	--name jekyllpublish \
 	-v $VOLUME_PATH:/content \
-	$SOURCE_URL sh -c "/generate.sh $GITHUB_URL $DEVNET_URL $BREADCRUMB $DIR_NAME $BRANCH"
+	$SOURCE_URL sh -c "/generate.sh $GITHUB_URL $DEVNET_URL $BREADCRUMB $DIR_NAME $BRANCH $BANNER_HTML_FILE"
 docker $TARGET_PREFIX rm jekyllpublish

--- a/generate/defaultBanner.html
+++ b/generate/defaultBanner.html
@@ -1,0 +1,6 @@
+<div>
+	<a class="homeButton" href="./">
+		<i class="fa fa-home fa-lg"></i> Home
+	</a>
+	<span class="banner">You are viewing an old version of this specification, for a full list of available versions see the <a href="./../">Developer Network project</a> page. </span>
+</div>

--- a/generate/generate.sh
+++ b/generate/generate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Usage: generate.sh git_url developer_network_api_page_url breadcrumb_name directory_name branch
+# Usage: generate.sh git_url developer_network_api_page_url breadcrumb_name directory_name branch banner_html_file
 GIT_URL=$1
 DN_URL=$2
 CRUMB=$3

--- a/generate/generate.sh
+++ b/generate/generate.sh
@@ -6,6 +6,7 @@ DN_URL=$2
 CRUMB=$3
 DIR_NAME=$4
 BRANCH=$5
+BANNER_HTML_FILE=$6
 
 ROOT_PATH="/content"
 TEMP_PATH="/content/tmp"
@@ -17,6 +18,7 @@ echo "DN URL: $DN_URL"
 echo "Breadcrumb: $CRUMB"
 echo "Directory: $DIR_NAME"
 echo "Branch: $BRANCH"
+echo "Banner HTML FILE: $BANNER_HTML_FILE"
 
 rm -Rf $ROOT_PATH/$DIR_NAME
 mkdir -p $ROOT_PATH/$DIR_NAME
@@ -77,7 +79,16 @@ echo '<!-- FROM GITHUB TEMPLATE -->' >> _layouts/default.html
 sed -n '/<script>/,/<\/head>/{x;p;d;}' _layouts/default-old.html >> _layouts/default.html
 echo '<!-- END FROM GITHUB TEMPLATE -->' >> _layouts/default.html
 cat /inline-styles.css >> _layouts/default.html # Inject some inline styles to tidy things up and resolve style clashes between Dev Net and Jekyll
+
 sed -n '/<\/head>/,/<div class="apicontent">/p' _layouts/devnet.html >> _layouts/default.html
+
+# If we need to add banner styling
+if [ -n "$BANNER_HTML_FILE" ]
+then
+	echo '<!-- include HTML from parameterised file in body -->' >> _layouts/default.html
+	cat $BANNER_HTML_FILE >> _layouts/default.html
+fi
+
 echo '<!-- FROM GITHUB TEMPLATE -->' >> _layouts/default.html
 sed -n '/<!-- Page Content -->/,/<\/body>/{x;p;d;}' _layouts/default-old.html >> _layouts/default.html
 echo '<!-- END FROM GITHUB TEMPLATE -->' >> _layouts/default.html

--- a/generate/inline-styles.css
+++ b/generate/inline-styles.css
@@ -43,5 +43,19 @@
 	.page_title h1 { margin-top: 0px; }
 	.page_title h2 { margin-top: 0px; padding-top: 0px; }
 
+	.banner {
+		padding: 10px;
+		background-color: #fffbdb;
+		border-radius: 5px;
+		margin: 5px;
+	}
+	
+	.homeButton {
+		padding: 10px;
+		background-color: #f2f2f2;
+		border-radius: 5px;
+		margin: 5px;
+	}
+	
 </style>
 


### PR DESCRIPTION
I have made the following changes:

1. I have updated the compilePages.sh to include another parameter for a HTML file to include in the generated pages.
2. I have change the generate.sh to add a banner HTML from a file location passed in as a parameter from the compilePages.sh if one is included. If no path to a file is included then no banner will be added to the page.
3. I added a default banner html file which can be used if you want to add a banner which has a link back to the developer network fhir page which shows all the projects. I have also included a home button which takes the user to the root page of the site as our old versions of the spec did not contain a back button to get back from sub elements of the specification.
4. I added some css for the default banner.