### PR TITLE
Add support for Ruby 2.4.3

### DIFF
--- a/generate/Dockerfile
+++ b/generate/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv
 RUN git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
 
 # Install Ruby into our environment
-RUN export PATH="/home/generator/.rbenv/bin:$PATH" && rbenv install 2.3.7 && rbenv global 2.3.7
+RUN export PATH="/home/generator/.rbenv/bin:$PATH" && rbenv install 2.4.3 && rbenv global 2.4.3
 
 # Install bundler and jekyll
 RUN export PATH="/home/generator/.rbenv/bin:$PATH" \


### PR DESCRIPTION
This adds a build step to the Dockerfile to use rbenv to install Ruby 2.4.3 as well as 2.3.7, which remains the global default